### PR TITLE
Fix of Key-Map

### DIFF
--- a/Server Files/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
+++ b/Server Files/Altis_Life.Altis/core/functions/fn_keyHandler.sqf
@@ -338,7 +338,7 @@ switch (_code) do
     };
 	
 	//Pickaxe - Q
-	case 41:
+	case 16:
 	{
 		if((!life_action_inUse) && (vehicle player == player) ) then
 		{


### PR DESCRIPTION
Changed the use of the picaxe from ^ to Q like its supposed.
https://community.bistudio.com/wiki/DIK_KeyCodes